### PR TITLE
introduce provider to manage app states

### DIFF
--- a/lib/domain/database/alertDatabase.dart
+++ b/lib/domain/database/alertDatabase.dart
@@ -47,9 +47,9 @@ class AlarmDatabase {
   }
 
   Future<Alert> create(Alert alert) async {
-    print( alert.toJson());
+    print( alert.toMap());
     final db = await instance.database;
-    final id = await db.insert(tableAlert, alert.toJson());
+    final id = await db.insert(tableAlert, alert.toMap());
     return alert.copy(id: id);
   }
 
@@ -85,7 +85,7 @@ class AlarmDatabase {
 
     return db.update(
       tableAlert,
-      alarm.toJson(),
+      alarm.toMap(),
       where: '${AlertFields.id} = ?',
       whereArgs: [alarm.id],
     );

--- a/lib/domain/database/alert_provider.dart
+++ b/lib/domain/database/alert_provider.dart
@@ -1,0 +1,51 @@
+import 'dart:ffi';
+
+import 'package:flutter/material.dart';
+import '../model/alert.dart';
+import 'alertDatabase.dart';
+
+class AlertProvider extends ChangeNotifier {
+  List<Alert> _items = [];
+  List<Alert> get items => _items;
+
+  String _filter = "all";
+  String _sortOrder = 'Ascending';
+  // TODO Kejun: need to improve above
+
+  Future insertDatabase(Alert alert) async {
+    AlarmDatabase.instance.create(alert);
+    _items.add(alert);
+
+    notifyListeners();
+  }
+
+  // Future<void> retrieveAlerts() async {
+  //   retrieveAlerts(true);
+  // }
+
+  Future<void> retrieveAlerts({bool shouldNotify = true}) async {
+    final dataList = await AlarmDatabase.instance.readAllAlerts();
+    _items = dataList;
+
+    if (shouldNotify) {
+      notifyListeners();
+    }
+  }
+
+  // TODO kejun: filter vs sort?? use enum instead of string
+  Future<void> setFilter(String filter) async {
+    _filter = filter;
+    // TODO kejun: need improve here, there is no status as "all", so needed to separate logic...
+    if (_filter == "all") {
+      retrieveAlerts(shouldNotify: false);
+    } else if (_filter == "pending" || _filter == "triggered") {
+      retrieveAlerts(shouldNotify: false);
+      _items= _items.where((alert) => alert.status.toString().split('.').last == _filter).toList();
+    } else if (_filter == 'Ascending') {
+      _items.sort((a, b) => a.expireTime.compareTo(b.expireTime));
+    } else if (_filter == 'Descending') {
+      _items.sort((a, b) => -a.expireTime.compareTo(b.expireTime));
+    }
+    notifyListeners();
+  }
+}

--- a/lib/domain/database/alert_provider.dart
+++ b/lib/domain/database/alert_provider.dart
@@ -30,17 +30,19 @@ class AlertProvider extends ChangeNotifier {
 
   Future<void> setFilter(String filter) async {
     _filter = filter;
-    runFilter();
+    await runFilter();
     runSort();
     notifyListeners();
   }
 
-  void runFilter() {
+  Future<void> runFilter() async {
     if (_filter == "all") {
-      retrieveAlerts(shouldNotify: false);
+      await retrieveAlerts(shouldNotify: false);
     } else if (_filter == "pending" || _filter == "triggered") {
-      retrieveAlerts(shouldNotify: false);
-      _items= _items.where((alert) => alert.status.toString().split('.').last == _filter).toList();
+      await retrieveAlerts(shouldNotify: false);
+      _items = _items
+          .where((alert) => alert.status.toString().split('.').last == _filter)
+          .toList();
     }
   }
 

--- a/lib/domain/database/alert_provider.dart
+++ b/lib/domain/database/alert_provider.dart
@@ -19,10 +19,6 @@ class AlertProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  // Future<void> retrieveAlerts() async {
-  //   retrieveAlerts(true);
-  // }
-
   Future<void> retrieveAlerts({bool shouldNotify = true}) async {
     final dataList = await AlarmDatabase.instance.readAllAlerts();
     _items = dataList;
@@ -32,20 +28,33 @@ class AlertProvider extends ChangeNotifier {
     }
   }
 
-  // TODO kejun: filter vs sort?? use enum instead of string
   Future<void> setFilter(String filter) async {
     _filter = filter;
-    // TODO kejun: need improve here, there is no status as "all", so needed to separate logic...
+    runFilter();
+    runSort();
+    notifyListeners();
+  }
+
+  void runFilter() {
     if (_filter == "all") {
       retrieveAlerts(shouldNotify: false);
     } else if (_filter == "pending" || _filter == "triggered") {
       retrieveAlerts(shouldNotify: false);
       _items= _items.where((alert) => alert.status.toString().split('.').last == _filter).toList();
-    } else if (_filter == 'Ascending') {
+    }
+  }
+
+  Future<void> setOrder(String order) async {
+    _sortOrder = order;
+    runSort();
+    notifyListeners();
+  }
+
+  void runSort() {
+    if (_sortOrder == 'Ascending') {
       _items.sort((a, b) => a.expireTime.compareTo(b.expireTime));
-    } else if (_filter == 'Descending') {
+    } else if (_sortOrder == 'Descending') {
       _items.sort((a, b) => -a.expireTime.compareTo(b.expireTime));
     }
-    notifyListeners();
   }
 }

--- a/lib/domain/model/alert.dart
+++ b/lib/domain/model/alert.dart
@@ -99,7 +99,7 @@ class Alert {
       repeatIntervalTimeInHours: json[AlertFields.repeatIntervalTimeInHours] as int,
       repeatIntervalTimeInMinutes: json[AlertFields.repeatIntervalTimeInMinutes] as int);
 
-  Map<String, Object?> toJson() => {
+  Map<String, Object?> toMap() => {
     AlertFields.id: id,
     AlertFields.status: status.toString().split('.').last,
     AlertFields.title: title,

--- a/lib/ui/component/alert_filter_bar.dart
+++ b/lib/ui/component/alert_filter_bar.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 
@@ -6,7 +5,7 @@ class AlertFilterBar extends StatefulWidget {
   final Function(String val) onFilterChanged;
   final Function(String val) onOrderChanged;
 
-  AlertFilterBar({super.key, required this.onFilterChanged, required this.onOrderChanged});
+  const AlertFilterBar({super.key, required this.onFilterChanged, required this.onOrderChanged});
 
   @override
   State<AlertFilterBar> createState() => _AlertFilterBarState();
@@ -19,19 +18,19 @@ class _AlertFilterBarState extends State<AlertFilterBar> {
   void showSortBottomSheet() {
     showModalBottomSheet(
       context: context,
-      shape: RoundedRectangleBorder(
+      shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(10)),
       ),
       builder: (BuildContext context) {
         return StatefulBuilder(
           builder: (BuildContext context, StateSetter setState) {
             return Container(
-                padding: EdgeInsets.all(16.0),
+                padding: const EdgeInsets.all(16.0),
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  Text(
+                  const Text(
                     'SORT BY',
                     style: TextStyle(
                       color: Colors.grey,
@@ -40,7 +39,7 @@ class _AlertFilterBarState extends State<AlertFilterBar> {
                     ),
                   ),
                   RadioListTile(
-                    title: Text('Ascending'),
+                    title: const Text('Ascending'),
                     value: 'Ascending',
                     groupValue: _currentOrder,
                     onChanged: (value) {
@@ -50,7 +49,7 @@ class _AlertFilterBarState extends State<AlertFilterBar> {
                     },
                   ),
                   RadioListTile(
-                    title: Text('Descending'),
+                    title: const Text('Descending'),
                     value: 'Descending',
                     groupValue: _currentOrder,
                     onChanged: (value) {
@@ -59,15 +58,15 @@ class _AlertFilterBarState extends State<AlertFilterBar> {
                       });
                     },
                   ),
-                  SizedBox(height: 10),
+                  const SizedBox(height: 10),
                   ElevatedButton(
                     onPressed: () {
-                      widget.onFilterChanged(_currentOrder);
+                      widget.onOrderChanged(_currentOrder);
                       Navigator.pop(context);
                     },
-                    child: Text('Apply'),
+                    child: const Text('Apply'),
                   ),
-                  SizedBox(height: 10),
+                  const SizedBox(height: 10),
                 ],
               ),
             );
@@ -80,7 +79,7 @@ class _AlertFilterBarState extends State<AlertFilterBar> {
   void showFilterBottomSheet() {
     showModalBottomSheet(
       context: context,
-      shape: RoundedRectangleBorder(
+      shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.only(
           topLeft: Radius.circular(16.0),
           topRight: Radius.circular(16.0),
@@ -95,7 +94,7 @@ class _AlertFilterBarState extends State<AlertFilterBar> {
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  Text(
+                  const Text(
                     'FILTER BY',
                     style: TextStyle(
                       color: Colors.grey,
@@ -103,11 +102,11 @@ class _AlertFilterBarState extends State<AlertFilterBar> {
                       fontSize: 15.0,
                     ),
                   ),
-                  SizedBox(height: 16.0),
+                  const SizedBox(height: 16.0),
                   Row(
                     children: [
                       FilterChip (
-                        label: Text('All'),
+                        label: const Text('All'),
                         selected: _currentFilter == 'all',
                         onSelected: (selected) {
                           setState(() {
@@ -115,9 +114,9 @@ class _AlertFilterBarState extends State<AlertFilterBar> {
                           });
                         },
                       ),
-                      SizedBox(width: 8.0),
+                      const SizedBox(width: 8.0),
                       FilterChip (
-                        label: Text('Pending'),
+                        label: const Text('Pending'),
                         selected: _currentFilter == 'pending',
                         onSelected: (selected) {
                           setState(() {
@@ -125,9 +124,9 @@ class _AlertFilterBarState extends State<AlertFilterBar> {
                           });
                         },
                       ),
-                      SizedBox(width: 8.0),
+                      const SizedBox(width: 8.0),
                       FilterChip (
-                        label: Text('Triggered'),
+                        label: const Text('Triggered'),
                         selected: _currentFilter == 'triggered',
                         onSelected: (selected) {
                           setState(() {
@@ -137,15 +136,15 @@ class _AlertFilterBarState extends State<AlertFilterBar> {
                       ),
                     ],
                   ),
-                  SizedBox(height: 16.0),
+                  const SizedBox(height: 16.0),
                   ElevatedButton(
                     onPressed: () {
                       widget.onFilterChanged(_currentFilter);
                       Navigator.pop(context);
                     },
-                    child: Text('Apply'),
+                    child: const Text('Apply'),
                   ),
-                  SizedBox(height: 10),
+                  const SizedBox(height: 10),
                 ],
               ),
             );
@@ -160,7 +159,7 @@ class _AlertFilterBarState extends State<AlertFilterBar> {
     return
       Container(
         color: Colors.grey[200],
-        padding: EdgeInsets.all(10),
+        padding: const EdgeInsets.all(10),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           children: [
@@ -170,7 +169,7 @@ class _AlertFilterBarState extends State<AlertFilterBar> {
                   showSortBottomSheet();
                 },
                 icon: Icon(Icons.sort, color: Colors.grey[300]),
-                label: Text(
+                label: const Text(
                   'Sort',
                   style: TextStyle(color: Colors.black),
                 ),
@@ -179,14 +178,14 @@ class _AlertFilterBarState extends State<AlertFilterBar> {
                 ),
               ),
             ),
-            SizedBox(width: 10),
+            const SizedBox(width: 10),
             Expanded(
               child: ElevatedButton.icon(
                 onPressed: () {
                   showFilterBottomSheet();
                 },
                 icon: Icon(Icons.filter_list, color: Colors.grey[300]),
-                label: Text(
+                label: const Text(
                   'Filter',
                   style: TextStyle(color: Colors.black),
                 ),

--- a/lib/ui/screen/main.dart
+++ b/lib/ui/screen/main.dart
@@ -209,10 +209,11 @@ class _MyHomePageState extends State<MyHomePage> {
                         children: [
                           AlertFilterBar(
                             onFilterChanged: (String filter) {
-                              // TODO Kejun: filter vs sort?
                               alertProvider.setFilter(filter);
                             },
-                            onOrderChanged: (String order) {},
+                            onOrderChanged: (String order) {
+                              alertProvider.setOrder(order);
+                            },
                           ),
                           Expanded(
                             child: ListView.builder(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  provider: ^6.0.3
   intl: 0.18.0
   flutter_slidable: 0.6.0
   font_awesome_flutter: 10.1.0


### PR DESCRIPTION
## Description
- introdue provider to manage app state, instead of inside widget, following this practice: https://docs.flutter.dev/development/data-and-backend/state-mgmt/simple
- implement sort and filter functionality inside the provider
- TODO: need to improve the code for sort and filter (e.g. TBD the status in database field, use enum instead of string when filter, separate filter and sort.)

https://user-images.githubusercontent.com/8712866/227282210-5a63018a-c902-4833-8752-a77d5cba2f11.mp4

## Type of change
- [ ] Chore (copy changes, version bump etc...)
- [ ] Bug fix (fixes an issue)
- [x] Refactor (modifies existing functionality)
- [x] New feature (adds functionality)

## Related issue links

## Checklists

- [x] Application changes have been tested thoroughly
- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
