### PR TITLE
fix the flickering issue in edit alert screen

### DIFF
--- a/lib/ui/component/alert_title_description.dart
+++ b/lib/ui/component/alert_title_description.dart
@@ -1,15 +1,15 @@
 import 'package:flutter/material.dart';
 
 class AlertTitleDescription extends StatelessWidget {
-  final TextEditingController? titleController;
-  final TextEditingController? descriptionController;
-  final GlobalKey<FormState> formKey; // TODO: not sure what's this
+  final String? title;
+  final String? description;
+  final GlobalKey<FormState> formKey; // TODO kejun: not sure what's this
   final ValueChanged<String> titleOnChanged;
   final ValueChanged<String> descriptionOnChanged;
 
   const AlertTitleDescription({super.key,
-    required this.titleController,
-    required this.descriptionController,
+    this.title,
+    this.description,
     required this.formKey,
     required this.titleOnChanged,
     required this.descriptionOnChanged});
@@ -33,7 +33,7 @@ class AlertTitleDescription extends StatelessWidget {
                 }
                 return null;
               },
-              controller: titleController,
+              initialValue: title,
               decoration: const InputDecoration(
                 filled: true,
                 hintText: 'Enter a title...',
@@ -48,7 +48,7 @@ class AlertTitleDescription extends StatelessWidget {
             height: 24,
           ),
           TextFormField(
-            controller: descriptionController,
+            initialValue: description,
             decoration: const InputDecoration(
               border: OutlineInputBorder(),
               filled: true,

--- a/lib/ui/screen/add_alert.dart
+++ b/lib/ui/screen/add_alert.dart
@@ -101,8 +101,6 @@ class _AddAlertPageState extends State<AddAlertPage> {
                   children: [
                     ...[
                       AlertTitleDescription(
-                          titleController: null,
-                          descriptionController: null,
                           formKey: _formKey,
                           titleOnChanged: (value) {
                             setState(() {

--- a/lib/ui/screen/edit_detail.dart
+++ b/lib/ui/screen/edit_detail.dart
@@ -11,9 +11,9 @@ import 'package:top_snackbar_flutter/top_snack_bar.dart';
 import '../../usecase/push_notification_service.dart';
 
 class AlertDetailPage extends StatefulWidget {
-  final int? id;
+  final Alert alert;
 
-  const AlertDetailPage(this.id, {super.key});
+  const AlertDetailPage({required this.alert, super.key});
 
   @override
   State createState() => _AlertDetailPageState();
@@ -39,37 +39,24 @@ class _AlertDetailPageState extends State<AlertDetailPage> {
   @override
   void initState() {
     super.initState();
-    _id = widget.id ?? -1;
-    initData();
+    Alert currentAlert = widget.alert;
+
+    _id = currentAlert.id ?? -1;
+    title = currentAlert.title;
+    description = currentAlert.description;
+    isImportant = currentAlert.isImportant;
+    daysToRepeat = currentAlert.repeatIntervalTimeInDays;
+    weekToRepeat = currentAlert.repeatIntervalTimeInWeeks;
+    hoursToRepeat = currentAlert.repeatIntervalTimeInHours;
+    minutesToRepeat = currentAlert.repeatIntervalTimeInMinutes;
+    needToRepeat = daysToRepeat != 0 ||
+        weekToRepeat != 0 ||
+        hoursToRepeat != 0 ||
+        minutesToRepeat != 0;
+    nextNotifyDate = currentAlert.expireTime;
+    nextNotifyTime =
+        TimeOfDay(hour: nextNotifyDate.hour, minute: nextNotifyDate.minute);
   }
-
-  Future<void> initData() async {
-    Alert current = await AlarmDatabase.instance.readAlert(_id);
-
-    setState(() {
-      title = current.title;
-      description = current.description;
-      isImportant = current.isImportant;
-      needToRepeat = current.repeatIntervalTimeInDays != 0 ||
-          current.repeatIntervalTimeInWeeks != 0 ||
-          current.repeatIntervalTimeInMinutes != 0 ||
-          current.repeatIntervalTimeInHours != 0;
-      daysToRepeat = current.repeatIntervalTimeInDays;
-      weekToRepeat = current.repeatIntervalTimeInWeeks;
-      hoursToRepeat = current.repeatIntervalTimeInHours;
-      minutesToRepeat = current.repeatIntervalTimeInMinutes;
-      nextNotifyDate = current.expireTime;
-      nextNotifyTime =
-          TimeOfDay(hour: nextNotifyDate.hour, minute: nextNotifyDate.minute);
-      titleTextController.text = title;
-      descriptionTextController.text = description;
-    });
-  }
-
-  TextEditingController titleTextController =
-      TextEditingController.fromValue(const TextEditingValue(text: ""));
-  TextEditingController descriptionTextController =
-      TextEditingController.fromValue(const TextEditingValue(text: ""));
 
   @override
   Widget build(BuildContext context) {
@@ -89,8 +76,8 @@ class _AlertDetailPageState extends State<AlertDetailPage> {
                   children: [
                     ...[
                       AlertTitleDescription(
-                          titleController: titleTextController,
-                          descriptionController: descriptionTextController,
+                          title: title,
+                          description: description,
                           formKey: _formKey,
                           titleOnChanged: (value) {
                             setState(() {

--- a/lib/ui/screen/main.dart
+++ b/lib/ui/screen/main.dart
@@ -129,7 +129,7 @@ class _MyHomePageState extends State<MyHomePage> {
           Navigator.of(context)
               .push(
                 MaterialPageRoute(
-                    builder: (context) => AlertDetailPage(currentAlert.id)),
+                    builder: (context) => AlertDetailPage(alert: currentAlert)),
               )
               .then((value) => setState(() {
                     refreshAllAlerts();


### PR DESCRIPTION
## Description
The root cause of flickering is because hint is shown before the alert is loaded from db. To fix it:
- pass the alert object from main to edit_alert screen, instead of passing id only
- don't asynchronizedly load data from db again

before fix:
https://user-images.githubusercontent.com/8712866/227660510-beacf838-586b-4f64-9ca0-d8d22cde6295.mp4

after fix:
https://user-images.githubusercontent.com/8712866/227660537-3cd3172e-53e9-4c5f-9087-cd89845fd31f.mp4

## Type of change
- [ ] Chore (copy changes, version bump etc...)
- [x] Bug fix (fixes an issue)
- [x] Refactor (modifies existing functionality)
- [ ] New feature (adds functionality)

## Related issue links

## Checklists

- [x] Application changes have been tested thoroughly
- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
